### PR TITLE
feat: remove botão de importação de dados do Header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -43,9 +43,6 @@ export function Header({ onExportSuccess, onSearchChange }: HeaderProps) {
         <button title="Filtrar">
           <FunnelIcon size={22} />
         </button>
-        <button title="Importar dados">
-          <UploadSimpleIcon size={22} />
-        </button>
         <button title="Exportar dados para CSV" onClick={handleExportClick}>
           <UploadSimpleIcon size={22} />
         </button>


### PR DESCRIPTION
### 📝 Descrição

Remove o botão 'Importar dados' do componente Header, mantendo apenas os botões de filtrar e exportar dados para CSV.

### 🔧 Mudanças

- Remove botão 'Importar dados' do Header
- Mantém botões de Filtrar e Exportar CSV

### 🧪 Como Testar

1.  Acesse a página onde o `Header` é renderizado.
2.  Verifique se o botão 'Importar dados' **não está** mais visível.
3.  Confirme que os botões 'Filtrar' e 'Exportar CSV' continuam presentes e funcionando como esperado.